### PR TITLE
fix: correct KERNEL substitution for nonfree package lines

### DIFF
--- a/build-iso.sh
+++ b/build-iso.sh
@@ -496,11 +496,12 @@ configure_kernel() {
   }" /usr/lib/manjaro-tools/util-iso-boot.sh
   
   # Replace kernel placeholders in package files
+  # Uses \bKERNEL\b instead of ^KERNEL to also match lines with prefixes like >nonfree_x86_64
   for pkg_file in "$PROFILE_PATH_EDITION"/Packages-*; do
     msg_info "Updating kernel references in $pkg_file"
-    sed -i "s/^KERNEL\b/linux${KERNEL_NAME}/g" "$pkg_file"
-    sed -i "s/^KERNEL-headers\b/linux${KERNEL_NAME}-headers/g" "$pkg_file"
-    sed -i "s/^KERNEL-\(.*\)/linux${KERNEL_NAME}-\1/g" "$pkg_file"
+    sed -i "s/\bKERNEL-headers\b/linux${KERNEL_NAME}-headers/g" "$pkg_file"
+    sed -i "s/\bKERNEL-\([a-z0-9_-]*\)/linux${KERNEL_NAME}-\1/g" "$pkg_file"
+    sed -i "s/\bKERNEL\b/linux${KERNEL_NAME}/g" "$pkg_file"
   done
 }
 


### PR DESCRIPTION
- Change sed patterns from ^KERNEL to word-boundary matching so KERNEL placeholder is expanded in lines prefixed with
  >nonfree_x86_64 (e.g. >nonfree_x86_64 KERNEL-nvidia)
- Reorder sed: headers first, then KERNEL-*, then bare KERNEL to prevent premature replacement
- Without this fix, nonfree packages with KERNEL in name were never resolved to the actual kernel version